### PR TITLE
fix(caesar-cipher): ensure positive result in decrypt method

### DIFF
--- a/src/lib/algorithms/caesar-cipher.ts
+++ b/src/lib/algorithms/caesar-cipher.ts
@@ -24,9 +24,13 @@ class CaesarCipher {
     for (let i = 0; i < str.length; i++) {
       const charCode = str.charCodeAt(i);
       if (charCode >= 65 && charCode <= 90) {
-        result += String.fromCharCode(((charCode - 65 - this.shift) % 26) + 65);
+        result += String.fromCharCode(
+          ((charCode - 65 - this.shift + 26) % 26) + 65
+        );
       } else if (charCode >= 97 && charCode <= 122) {
-        result += String.fromCharCode(((charCode - 97 - this.shift) % 26) + 97);
+        result += String.fromCharCode(
+          ((charCode - 97 - this.shift + 26) % 26) + 97
+        );
       } else {
         result += str.charAt(i);
       }


### PR DESCRIPTION
Resolve an issue in the decrypt function where the modulo operation could result in negative value. Added +26 to ensure the result is always positive.

#3